### PR TITLE
allow path set with env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ start-frontend.sh
 start-node.sh
 start-all.sh
 old-extrinsics.rs.backup
+/blockstore/ # default storing folder for the IPFS node

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ start-frontend.sh
 start-node.sh
 start-all.sh
 old-extrinsics.rs.backup
-/blockstore/ # default storing folder for the IPFS node
+# default storing folder for the IPFS node ###
+/blockstore

--- a/utils/rust-ipfs/src/lib.rs
+++ b/utils/rust-ipfs/src/lib.rs
@@ -262,7 +262,12 @@ impl IpfsOptions {
     ///
     /// Also used from examples.
     pub fn inmemory_with_generated_keys() -> Self {
-        IpfsOptions {
+		let ipfs_path = match env::var("IPFS_PATH") {
+			Ok(val) => PathBuf::from(val),
+			Err(_) => env::current_dir().unwrap()
+		};
+		IpfsOptions {
+			ipfs_path,
             ..Default::default()
         }
     }


### PR DESCRIPTION
**Changelog**

- allow env var to set ipfs path
- use current_dir as default instead of a temp folder